### PR TITLE
Use the clipboard api on `copy`

### DIFF
--- a/src/client/components/SchematicCard.svelte
+++ b/src/client/components/SchematicCard.svelte
@@ -5,8 +5,8 @@
   import IconButton from './buttons/IconButton.svelte';
   import { toast } from '@zerodevx/svelte-toast';
   export let schematic: BasicSchematicJSON;
-  function copySchematic() {
-    copy(schematic.text);
+  async function copySchematic() {
+    await copy(schematic.text);
     toast.push('Copied to clipboard!');
   }
 </script>

--- a/src/client/copy.ts
+++ b/src/client/copy.ts
@@ -3,14 +3,18 @@
  * @param text The text to be copied
  * @returns `true` if the operation was successful, else returns `false`
  */
-export function copy(text: string): boolean {
+export async function copy(text: string): Promise<boolean> {
+  if ('clipboard' in navigator) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   const textArea = document.createElement('textarea');
+  textArea.style.display = 'none';
   textArea.value = text;
-
-  // Avoid scrolling to bottom
-  textArea.style.top = '0';
-  textArea.style.left = '0';
-  textArea.style.position = 'fixed';
 
   document.body.appendChild(textArea);
 

--- a/src/client/share.ts
+++ b/src/client/share.ts
@@ -13,7 +13,7 @@ export async function share(
         url,
       });
     } else {
-      copy(url);
+      await copy(url);
     }
     // eslint-disable-next-line no-empty
   } catch (e) {}

--- a/src/routes/schematics/[id]/index.svelte
+++ b/src/routes/schematics/[id]/index.svelte
@@ -47,7 +47,7 @@
     'pyratite',
   ];
   async function copySchematic() {
-    copy(schematic.text);
+    await copy(schematic.text);
     toast.push('Copied to Clipboard!');
   }
 </script>


### PR DESCRIPTION
Now `copy` will prefer the modern clipboard api before using the deprecated `document.execCommand("copy")` method.