### PR TITLE
Fix schematic details page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
   :root {
     --toastContainerTop: 5rem;
     --toastContainerRight: 1rem;
+    --bottom-bar-height: 4rem;
   }
   .loader {
     position: fixed;

--- a/static/css/tags.css
+++ b/static/css/tags.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: start;
-  width: max-content;
+  /* width: max-content; */
   gap: 1em;
   max-width: 100%;
 }


### PR DESCRIPTION
Fixes the layout of the schematic details page, which didn't have a properly spaced bottom bar and had the tags div breaking the layout on mobile devices.